### PR TITLE
Increase code coverage by adding tests for `typevars(T::UnionAll)`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,4 +37,15 @@ using Test
         @test g(1) === 14
     end
 
+    let
+        a = Vector{T} where T
+        b = CodeTransformation.typevars(a)
+        @test b isa Tuple
+        @test length(b) == 1
+        @test b[1] isa TypeVar
+        @test b[1].name == :T
+        @test b[1].lb === Union{}
+        @test b[1].ub === Any
+    end
+
 end


### PR DESCRIPTION
Currently, the code coverage on the `master` branch is `93.75% `.

This pull request increases the code coverage by `6.25` percentage points to `100%` by adding tests for `typevars(T::UnionAll)`.

cc: @perrutquist 
